### PR TITLE
fix(xss): Sanitize HTML in Tiptap Raw node rendering

### DIFF
--- a/app/javascript/components/TiptapExtensions/MediaEmbed.tsx
+++ b/app/javascript/components/TiptapExtensions/MediaEmbed.tsx
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 import { Editor, Node as TiptapNode, Extension } from "@tiptap/core";
 import { DOMOutputSpec } from "@tiptap/pm/model";
 import { NodeViewProps, NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
@@ -64,7 +65,7 @@ export const Raw = TiptapNode.create({
   renderHTML: ({ HTMLAttributes }) => {
     const doc = document.createElement("div");
     doc.className = "tiptap__raw";
-    doc.innerHTML = cast(HTMLAttributes.html);
+    doc.innerHTML = DOMPurify.sanitize(cast(HTMLAttributes.html));
     if (HTMLAttributes.title) doc.setAttribute("data-title", cast(HTMLAttributes.title));
     if (HTMLAttributes.url) doc.setAttribute("data-url", cast(HTMLAttributes.url));
     if (HTMLAttributes.thumbnail) doc.setAttribute("data-thumbnail", cast(HTMLAttributes.thumbnail));

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "core-js": "^3.27.1",
         "date-fns": "^3.0.0",
         "date-fns-tz": "^3.0.0",
+        "dompurify": "^3.2.5",
         "fast-average-color": "^9.4.0",
         "immer": "^10.0.0",
         "jquery": "^3.6.3",
@@ -3541,6 +3542,13 @@
       "integrity": "sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg==",
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -6119,6 +6127,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.5.tgz",
+      "integrity": "sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "core-js": "^3.27.1",
     "date-fns": "^3.0.0",
     "date-fns-tz": "^3.0.0",
+    "dompurify": "^3.2.5",
     "fast-average-color": "^9.4.0",
     "immer": "^10.0.0",
     "jquery": "^3.6.3",


### PR DESCRIPTION
This PR fixes a DOM XSS vulnerability in the Tiptap editor's Raw node. The vulnerability was caused by unsafe  assignment in the  function, which allowed for the execution of arbitrary JavaScript.

To remediate this, I have added the  library and used it to sanitize the HTML content before it is assigned to  in . This ensures that any malicious HTML is neutralized.

Files modified:
- /app/gumroad/app/javascript/components/TiptapExtensions/MediaEmbed.tsx
- /app/gumroad/package.json
- /app/gumroad/package-lock.json (updated by npm install)

The patch addresses the root cause by sanitizing the untrusted HTML input. I have kept the Raw extension as removing it might break existing content, and the sanitization mitigates the risk.