### PR TITLE
fix(security): Sanitize iframe.ly embed HTML to prevent XSS

### DIFF
--- a/app/javascript/components/TiptapExtensions/MediaEmbed.tsx
+++ b/app/javascript/components/TiptapExtensions/MediaEmbed.tsx
@@ -243,7 +243,7 @@ export const ExternalMediaFileEmbed = TiptapNode.create({
     return ReactNodeViewRenderer(({ editor, node, deleteNode }: NodeViewProps) => (
       <NodeViewWrapper>
         <div className="embed">
-          <div className="preview" dangerouslySetInnerHTML={{ __html: cast(node.attrs.html) }}></div>
+          <div className="preview" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(cast(node.attrs.html)) }}></div>
           <div className="content">
             <Icon name="file-earmark-play-fill" className="type-icon" />
             <div>
@@ -273,4 +273,5 @@ export const ExternalMediaFileEmbed = TiptapNode.create({
       insertMediaEmbed: createInsertCommand("mediaEmbed"),
     };
   },
+import DOMPurify from 'dompurify';
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "core-js": "^3.27.1",
         "date-fns": "^3.0.0",
         "date-fns-tz": "^3.0.0",
+        "dompurify": "^3.2.5",
         "fast-average-color": "^9.4.0",
         "immer": "^10.0.0",
         "jquery": "^3.6.3",
@@ -3541,6 +3542,13 @@
       "integrity": "sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg==",
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -6119,6 +6127,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.5.tgz",
+      "integrity": "sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "core-js": "^3.27.1",
     "date-fns": "^3.0.0",
     "date-fns-tz": "^3.0.0",
+    "dompurify": "^3.2.5",
     "fast-average-color": "^9.4.0",
     "immer": "^10.0.0",
     "jquery": "^3.6.3",


### PR DESCRIPTION
This pull request fixes a DOM-based XSS vulnerability in the media embedding workflow by sanitizing the iframe.ly output using DOMPurify.

Vulnerability: GUM-01-003 WP1 [High] DOM-based XSS via iframe.ly Embed Handling in MediaEmbed.tsx

Files modified:
- app/javascript/components/TiptapExtensions/MediaEmbed.tsx
- package.json
- package-lock.json

The patch addresses the vulnerability by:
- Adding DOMPurify as a dependency.
- Importing DOMPurify in MediaEmbed.tsx.
- Sanitizing the  using  before it is used in .

This ensures that any potentially malicious HTML received from iframe.ly is neutralized before being injected into the DOM, preventing XSS attacks.