### PR TITLE
fix(security): Stored XSS via Seller Display Name in Receipt Generation

### DIFF
--- a/app/presenters/receipt_presenter/charge_info.rb
+++ b/app/presenters/receipt_presenter/charge_info.rb
@@ -32,7 +32,7 @@ class ReceiptPresenter::ChargeInfo
       else
         "Contact #{h(seller.display_name)} at #{mail_to(seller.support_or_form_email)}."
       end
-    "#{question} #{action}".html_safe
+    "#{question} #{action}"
   rescue NotImplementedError
     nil
   end


### PR DESCRIPTION
This PR fixes a Stored XSS vulnerability in the receipt generation flow.

The vulnerability was caused by improper handling of the seller's display name, which was not properly escaped before being marked as html_safe.

Changes made:
- Removed  from the  method in .

This patch ensures that the seller's display name is properly escaped when rendered in the receipt views, preventing the execution of malicious JavaScript.