### PR TITLE
fix(security): Prevent unauthenticated affiliate request approval (IDOR)

### DIFF
--- a/app/controllers/affiliate_requests_controller.rb
+++ b/app/controllers/affiliate_requests_controller.rb
@@ -3,7 +3,7 @@
 class AffiliateRequestsController < ApplicationController
   include CustomDomainConfig
 
-  PUBLIC_ACTIONS = %i[new create approve ignore]
+  PUBLIC_ACTIONS = %i[new create]
   before_action :authenticate_user!, except: PUBLIC_ACTIONS
 
   before_action :set_user_and_custom_domain_config, only: %i[new create]
@@ -109,7 +109,7 @@ class AffiliateRequestsController < ApplicationController
     end
 
     def set_affiliate_request
-      @affiliate_request = AffiliateRequest.find_by_external_id!(params[:id])
+    @affiliate_request = current_seller.affiliate_requests.find_by_external_id!(params[:id])
     end
 
     def permitted_create_params


### PR DESCRIPTION
This PR fixes an IDOR/BOLA vulnerability in the affiliate request approval flow.

**Vulnerability Summary:**
An unauthenticated attacker could approve any pending affiliate request if they knew or could guess a valid  due to missing authorization checks.

**Files Modified:**
- 

**How the patch addresses the issue:**
- Removed  and  actions from  to require authentication.
- Modified the  method to scope the  lookup to the , ensuring that only the owner of the affiliate request can access it.

**Assumptions or potential side effects:**
- Assumes  is available and correctly identifies the authenticated user who is a seller.
- No expected side effects on legitimate functionality as the changes only enforce existing authorization logic that was previously bypassed.